### PR TITLE
fix: 火狐等部分浏览器奇怪的性能优化逻辑 导致svg计算错误

### DIFF
--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -74,7 +74,8 @@ define(function(require, exports, module) {
         },
 
         setVisible: function(v) {
-            this._rc.setVisible(v);
+            this._rc.setStyle('opacity', v ? 1 : 0);
+            // this._rc.setVisible(v);
         }
     });
 });


### PR DESCRIPTION
fix: 火狐等部分浏览器奇怪的性能优化逻辑 导致svg计算错误